### PR TITLE
security proxy filters are not recursive

### DIFF
--- a/security-proxy/maven.filter
+++ b/security-proxy/maven.filter
@@ -8,15 +8,15 @@ authoritiesBaseDN=@shared.ldap.groupSearchBaseDN@
 ldapAdminDn=@shared.ldap.admin.dn@
 ldap.admin.password=@shared.ldap.admin.password@
 
-cas.public.host=${public_host}
+cas.public.host=@shared.server.name@
 cas.private.host=localhost
 
 defaultTarget.port=8080
 public.ssl=443
 private.ssl=8443
-geoserver.server=http://${public_host}:${defaultTarget.port}
+geoserver.server=http://@shared.server.name@:8080
 
-proxy.defaultTarget=http://localhost:${defaultTarget.port}
+proxy.defaultTarget=http://localhost:8080
 proxy.mapping=\
     <entry key="extractorapp" value="${proxy.defaultTarget}/extractorapp-private/" />\
     <entry key="mapfishapp" value="${proxy.defaultTarget}/mapfishapp-private/" />\


### PR DESCRIPTION
Had to remove recursive property references (${public_host}) because they won't be resolved during build because security does not allow recursive resolution.  
