### PR TITLE
Do not provide an nonexistent URL for default PDF URL - better empty.

### DIFF
--- a/build_support/shared.maven.filters
+++ b/build_support/shared.maven.filters
@@ -203,11 +203,13 @@ shared.psql.pass=www-data
 # + example +
 # shared.download_form.activated=false
 # shared.psql.download_form.db=downloadform
-# shared.download_form.pdfurl=/header/usage.pdf
+# shared.download_form.pdfurl=/_static/usage.pdf
+# or
+# shared.download_form.pdfurl=//url.to/cgu.pdf
 #
 shared.download_form.activated=false
 shared.psql.download_form.db=downloadform
-shared.download_form.pdfurl=/header/usage.pdf
+shared.download_form.pdfurl=
 
 
 # --------------------------------------------------


### PR DESCRIPTION
And modules that use it should (they do) manage the case of an
empty URL.
